### PR TITLE
delete and reset ranking (for autocompletion address)

### DIFF
--- a/tests/test_zimbra_mail.py
+++ b/tests/test_zimbra_mail.py
@@ -149,6 +149,18 @@ class PythonicZimbraMailAPITests(unittest.TestCase):
         self.assertTrue(new_zc._session.is_logged_in())
         self.assertTrue(new_zc.is_session_valid())
 
+    # Raking actions
+
+    def test_delete_ranking(self):
+        # No means to check it's really deleted because we
+        # can't access the list and no error is thrown if
+        # there is no entry with this address.
+        self.zc.delete_ranking(email='p.martin@example.com')
+
+    def test_reset_ranking(self):
+        # Same as above, no means to check it's really reseted.
+        self.zc.reset_ranking()
+
 
 class ZobjectTaskTests(unittest.TestCase):
     """ Tests the Task zobject.

--- a/zimsoap/client.py
+++ b/zimsoap/client.py
@@ -907,6 +907,22 @@ class ZimbraMailClient(ZimbraAbstractClient):
         # !!! We need to authenticate with the 'urn:zimbraAccount' namespace
         self._session.login(user, password, 'urn:zimbraAccount')
 
+    # Ranking action
+
+    def reset_ranking(self):
+        """Reset the contact ranking table for the account
+        """
+        self.request('RankingAction', {'action': {'op': 'reset'}})
+
+    def delete_ranking(self, email):
+        """Delete a specific address in the auto-completion of the users
+
+        :param email: the address to remove
+        """
+        self.request('RankingAction', {'action': {'op': 'reset',
+                                                  'email': email
+                                                  }})
+
     def create_task(self, subject, desc):
         """Create a task
 


### PR DESCRIPTION
This is to flush contacts kept in the autocompletion selection.