### PR TITLE
Case insensitive signature name

### DIFF
--- a/tests/test_zimbra_account.py
+++ b/tests/test_zimbra_account.py
@@ -235,6 +235,19 @@ class PythonicAccountAPITests(unittest.TestCase):
         self.assertIsInstance(resp, Signature)
         self.assertEqual(resp, sig1)
 
+    def test_get_a_signature_by_name_case_insensitive(self):
+        """ Zimbra considers that the signature name should be unique
+
+        two signatures with same name, diferently cased is not allowed, so it's
+        logical to be able to query a signature with any case.
+        """
+        sig1 = self.zc.create_signature('unittest', 'CONTENT', "text/html")
+        self.zc.create_signature('unittest1', 'CONTENT', "text/html")
+
+        resp = self.zc.get_signature(Signature(name='unitTEST'))
+        self.assertIsInstance(resp, Signature)
+        self.assertEqual(resp, sig1)
+
     def test_get_a_signature_by_nonexistant_name_returns_none(self):
         resp = self.zc.get_signature(Signature(name='idonotexist'))
         self.assertEqual(resp, None)

--- a/tests/test_zimbra_account.py
+++ b/tests/test_zimbra_account.py
@@ -12,7 +12,7 @@ import unittest
 
 from six import text_type, binary_type
 
-from . import utils
+from zimsoap import utils
 from zimsoap.client import (ZimbraAccountClient, ZimbraSoapServerError,
                             ZimbraAdminClient)
 from zimsoap.zobjects import Signature, Identity

--- a/zimsoap/client.py
+++ b/zimsoap/client.py
@@ -348,6 +348,8 @@ class ZimbraAccountClient(ZimbraAbstractClient):
     def get_signature(self, signature):
         """Retrieve one signature, discriminated by name or id.
 
+        Note that signature name is not case sensitive.
+
         :param: a zobjects.Signature describing the signature
                like "Signature(name='my-sig')"
 
@@ -364,7 +366,7 @@ class ZimbraAccountClient(ZimbraAbstractClient):
                 if hasattr(signature, 'id'):
                     its_this_one = (sig.id == signature.id)
                 elif hasattr(signature, 'name'):
-                    its_this_one = (sig.name == signature.name)
+                    its_this_one = (sig.name.upper() == signature.name.upper())
                 else:
                     raise ValueError('should mention one of id,name')
                 if its_this_one:


### PR DESCRIPTION
See in-code comments for rationale, but in a word, it was leading to some weird behavior while using zimsoap signature-setting scripts, there was no way to check if setting a signature with a given name would succeed or not.